### PR TITLE
input: misc: hbtp_input: Report 4 times the pressure value

### DIFF
--- a/drivers/input/misc/hbtp_input.c
+++ b/drivers/input/misc/hbtp_input.c
@@ -37,8 +37,6 @@
 
 #define HBTP_INPUT_NAME			"hbtp_input"
 #define DISP_COORDS_SIZE		2
-#undef HBTP_MAX_FINGER
-#define HBTP_MAX_FINGER 10
 
 #define HBTP_PINCTRL_VALID_STATE_CNT		(2)
 #define HBTP_HOLD_DURATION_US			(10)
@@ -360,6 +358,7 @@ static int hbtp_input_report_events(struct hbtp_data *hbtp_data,
 					MT_TOOL_FINGER, tch->active);
 
 			if (tch->active) {
+				tch->pressure *= 4;
 				input_report_abs(hbtp_data->input_dev,
 						ABS_MT_TOOL_TYPE,
 						tch->tool);


### PR DESCRIPTION
The pressure value that's reported is about 1/4 of the value
it should actually be (compared to a phone with normal
touchscreen drivers). Fix it by reporting 4x that value.
Also remove MAX_FINGER hacks.

Signed-off-by: celtare21 <celtare21@gmail.com>