### PR TITLE
unfok le dongle

### DIFF
--- a/drivers/base/power/qos.c
+++ b/drivers/base/power/qos.c
@@ -284,7 +284,7 @@ void dev_pm_qos_constraints_destroy(struct device *dev)
 	dev->power.qos = ERR_PTR(-ENODEV);
 	spin_unlock_irq(&dev->power.lock);
 
-	kfree(qos->resume_latency.notifiers);
+	kfree(c->notifiers);
 	kfree(qos);
 
  out:


### PR DESCRIPTION
Breaks dongle and a man without a working dongle is a sad man.

This reverts commit a64076d2e2248465c94b4c6b4ebce8f52638c8f1.

Signed-off-by: celtare21 <celtare21@gmail.com>
Signed-off-by: Andrew Ozahoski <aozahoski@gmail.com>