### PR TITLE
mdss_fb: Change the way we adjust X res offset

### DIFF
--- a/drivers/video/fbdev/msm/mdss_fb.c
+++ b/drivers/video/fbdev/msm/mdss_fb.c
@@ -3641,7 +3641,7 @@ void mdss_panelinfo_to_fb_var(struct mdss_panel_info *pinfo,
 {
 	u32 frame_rate;
 
-	if (strnstr(saved_command_line, "skip_initramfs",
+	if (strnstr(saved_command_line, "androidboot.mode=recovery",
                     strlen(saved_command_line))) {
                 var->xres = mdss_fb_get_panel_xres(pinfo) - 128;
         } else {


### PR DESCRIPTION
* Determine the boot target based on androidboot.mode instead of
the presence of skip_initramfs in the cmdline

* This change fixes a long reported issue where devices running
Magisk have too much display panel shift while in Android due to
the cmdline patches applied by Magisk at runtime.